### PR TITLE
Fixed: select breaks publishing

### DIFF
--- a/src/select/ko/selectInput.html
+++ b/src/select/ko/selectInput.html
@@ -3,7 +3,7 @@
     <label data-bind="text: label"></label>
     <!-- /ko -->
 
-    <select data-bind="styled: styles, attr: { required: required, readonly: readonly }, foreach: options">
+    <select data-bind="styled: styles, attr: { required: required, readonly: readonly, value: value }, foreach: options">
         <option data-bind="attr: { value: value }"> <!--ko text: label--><!--/ko--></option>
     </select>
 </div>

--- a/src/select/ko/selectInput.html
+++ b/src/select/ko/selectInput.html
@@ -3,6 +3,7 @@
     <label data-bind="text: label"></label>
     <!-- /ko -->
 
-    <select data-bind="styled: styles, options: options, value: value, optionsText: 'label', optionsValue: 'value', attr: { required: required, readonly: readonly }">
+    <select data-bind="styled: styles, attr: { required: required, readonly: readonly }, foreach: options">
+        <option data-bind="attr: { value: value }"> <!--ko text: label--><!--/ko--></option>
     </select>
 </div>


### PR DESCRIPTION
## Problem
During publishing, when `KnockoutHtmlPagePublisherPlugin` is rendering the html content, ko is throwing the following error: `TypeError: Unable to process binding "options: function(){return options }"`
This happens because the bindings of the `<select>`  (options) are not under the `attr` binding.


## Solution
When rendering the `<select>`, foreach through the options and display them.